### PR TITLE
Delete Audio File, WordBreak on Filename, Removed Filetype and filesize, and added more infos

### DIFF
--- a/dashboard1.php
+++ b/dashboard1.php
@@ -7,7 +7,61 @@
     }
 
     require("utilities/faqs.php");
+     
+    // 2
+    $total_audio = "SELECT COUNT(*) FROM text_translations WHERE user_id = '" . $_SESSION['user_id'] . "' and from_audio_file = 1";
+    $total_audio_result = mysqli_query($dbcon, $total_audio);
+    $audio_result_row = mysqli_fetch_array($total_audio_result);
+   
+    $total_audio = $audio_result_row[0];
 
+
+    $total_text = "SELECT COUNT(*) FROM text_translations WHERE user_id = '" . $_SESSION['user_id'] . "' AND from_audio_file = 0";
+    $total_text_result = mysqli_query($dbcon, $total_text);
+    
+    $text_result_row = mysqli_fetch_array($total_text_result);
+
+    $total_text = $text_result_row[0];
+
+    $total_message_array = array();
+    
+    // message to display on TEXT TO TEXT part
+    if ($total_text == 0) {
+        // message to display if user hasn't translated in text to text yet.
+        array_push($total_message_array, "Translate Now in Text to Text translation!");
+
+    } else if ($total_text > $total_audio) {
+        // message to display if user translated MORE in text to text
+        array_push($total_message_array, "You have been using Text to Text more with a total of  <b>" . $total_text . "</b> times.");
+    
+    } else if ($total_text < $total_audio) {
+        // message to display if user translated LESS in text to text
+        array_push($total_message_array, "You have a total of <b>" . $total_text . "</b> Text to Text translation.");
+    
+    } else if ($total_text == $total_audio) {
+        // message to display if user both utilized text and audio the same
+        array_push($total_message_array, "You have been using both Text to Text and Audio to Text translation with a total of <b>" . $total_text . "</b> times.");
+    }
+    
+    // message to display on AUDIO TO TEXT part
+    if ($total_audio == 0) {
+      // message to display if user hasn't translated in audio to text yet.
+      array_push($total_message_array, "You haven't translated any audio yet! Translate one now!");
+
+    } else if ($total_audio > $total_text) {
+      // message to display if user translated MORE in audio to text
+      array_push($total_message_array, "You have been using Audio to Text more with a total of  <b>" . $total_audio . "</b> times.");
+    
+    } else if ($total_audio < $total_text) {
+      // message to display if user translated LESS in audio to text
+      array_push($total_message_array, "You have a total of <b>" . $total_audio . "</b> audio to text translation.");
+    
+    } else if ($total_audio == $total_text) {
+      // message to display if user both utilized text and audio the same
+      array_push($total_message_array, "Thank you for using both Text to Text and Audio to Text Translation Service!");
+    }
+
+                              
 ?>
 
 <!DOCTYPE html>
@@ -160,6 +214,8 @@
             
             <!-- End of Insights -->
             <div class="bottom-data">
+
+                <!-- Text to Text Translation -->
                 <div class="orders">
                     <div class="header">
                             <img src="images/translateicon.png" width="120px" height="100px">
@@ -169,13 +225,15 @@
                             </p>
                             <button class="button"><a href="text-text.php" class="logo">START TRANSLATING TEXT
                                 <i class="fa fa-arrow-circle-o-right"></i></button></a>
+                            
                     </div>
                 </div>
                 
-                <!-- Reminders -->
+
+                <!-- Audio to Text Translation -->
                 <div class="orders">
                     <div class="header">
-                    <img src="images/languageicon.png" width="120px" height="100px">
+                            <img src="images/languageicon.png" width="120px" height="100px">
                             <h3>Audio to Text Translation</h3>      
                             <p class="description">
                             Upload your audio file to smoothly translate it into another language, breaking the language barrier.
@@ -186,6 +244,17 @@
                     <br>
                 </div>
 
+                
+                <div class="orders">
+                  <div class="header">
+                    <span style="font-size: 1.3em; text-align:center;"><?php echo $total_message_array[0]; ?></span>
+                  </div>
+                </div>
+                <div class="orders">
+                  <div class="header">
+                    <span style="font-size: 1.3em; text-align:center;"><?php echo $total_message_array[1]; ?></span>
+                  </div>
+                </div>
             </div>
 
 <div class="accordion">

--- a/delete_query.php
+++ b/delete_query.php
@@ -72,7 +72,7 @@ if($_POST['clearAll'] == 'true'){
     //deletes audio file record from database if it's an audio to text translation
     if($_POST['fileId'] != null){
         
-        deleteAudioFiles($fileId, $userId);
+        deleteAudioFile($fileId, $userId);
         
         $deleteQuery = mysqli_prepare($dbcon, "DELETE FROM audio_files WHERE file_id = ?");
         bindAndExec($deleteQuery, "s", $fileId); 
@@ -98,80 +98,3 @@ function bindAndExec($stmt, $markers, $value){
     mysqli_stmt_execute($stmt);
 }
 
-
-
-function removeFolder($path) {
-    // process of deleting the folder in audio files
-    if (is_dir($path)) {
-        $iterator = new DirectoryIterator($path);
-    
-        
-        // loop through each content inside the folder
-        foreach($iterator as $file) {
-            if ($file->isFile()) {
-                unlink($file->getRealPath()); // get the relative path and delete the file
-            } elseif (!$file->isDot() && $file->isDir()) {
-                rmdir($file->getRealPath()); // get the relative path and delete the folder
-            }
-        }
-        
-        // finally, delete the now-empty folder
-        rmdir($path);
-    }
-}
-
-function fetchAudioContent($fileid) {
-    global $dbcon;
-    $datequery = "SELECT file_name, DATE_FORMAT(upload_date, '%m%d%Y_%H%i%s') AS formatted_date 
-                        FROM audio_files WHERE file_id = '$fileid'";
-    $dateresult = mysqli_query($dbcon, $datequery);
-
-    $audiofile =  mysqli_fetch_assoc($dateresult);
-
-    // get the filename and extension
-    $filename = pathinfo($audiofile['file_name'], PATHINFO_FILENAME);
-    $extension = pathinfo($audiofile['file_name'], PATHINFO_EXTENSION);
-
-    // put filename, extension and date in array, these infos are needed to select
-    //  specific record from the database in order to delete a specific file
-    $info = array("filename" => $filename, 
-                "extension" => $extension,
-                "formatted_date" => $audiofile['formatted_date']);
-
-    return $info;
-}
-
-function deleteAudioFile($fileid) {
-    //get the audio file content from the database, to be used on locating the filename in audio_files folder
-    $audiofile = fetchAudioContent($fileid);
-
-    // remove the audio file uploaded by user
-    $filenameMask = "audio_files/" . $userId . "_" . $audiofile['filename'] . $audiofile['formatted_date'] . "." . $audiofile['extension']; 
-    if (file_exists($filenameMask)) 
-        unlink($filenameMask);
-    
-    // remove the folder created on specific file and all its contents
-    $folderMask = "audio_files/" . $userId . "_" . $audiofile['filename'] . $audiofile['formatted_date'];
-    removeFolder($folderMask);
-}
-
-function deleteAllAudioFiles() {
-    // since we delete all, get all the files and folder that has the user_id in file
-    $mask = "audio_files/" . $userId . "_*";
-
-    // put all the folder/filenames that matches the $mask in an array
-    $items = glob($mask);
-
-    
-    foreach ($items as $file) {
-    
-        // check if it's an audio file or a folder, then delete them 
-        //  using their designated step
-        if (is_file($file)) {
-            unlink($file);
-        } elseif (is_dir($file)) {
-            removeFolder($file);
-        }
-    
-    }
-}

--- a/delete_query.php
+++ b/delete_query.php
@@ -1,6 +1,6 @@
 <?php
  require("mysql/mysqli_connect.php"); 
-
+ require("utilities/delete_files.php");
 
  
 if($_POST['clearAll'] == 'true'){
@@ -15,7 +15,7 @@ if($_POST['clearAll'] == 'true'){
         bindAndExec($deleteQuery, "s", $userId);
 
 
-        deleteAllAudioFiles();
+        deleteAllAudioFiles($userId);
         
     }
     else{            
@@ -37,7 +37,7 @@ if($_POST['clearAll'] == 'true'){
                 $deleteFiles =$filesToDelete[$i];
                 
 
-                deleteAudioFile($deleteFiles);
+                deleteAudioFile($deleteFiles, $userId);
 
                 
                 $deleteQuery = mysqli_prepare($dbcon, "DELETE FROM text_translations WHERE text_id = ?");
@@ -72,7 +72,7 @@ if($_POST['clearAll'] == 'true'){
     //deletes audio file record from database if it's an audio to text translation
     if($_POST['fileId'] != null){
         
-        deleteAudioFiles($fileId);
+        deleteAudioFiles($fileId, $userId);
         
         $deleteQuery = mysqli_prepare($dbcon, "DELETE FROM audio_files WHERE file_id = ?");
         bindAndExec($deleteQuery, "s", $fileId); 

--- a/delete_query.php
+++ b/delete_query.php
@@ -66,11 +66,12 @@ if($_POST['clearAll'] == 'true'){
 
     $rowId = $_POST['rowId'];
     $fileId = $_POST['fileId'];
+    
     $deleteQuery = mysqli_prepare($dbcon, "DELETE FROM text_translations WHERE text_id = ?");
     bindAndExec($deleteQuery, "s", $rowId); 
 
     //deletes audio file record from database if it's an audio to text translation
-    if($_POST['fileId'] != null){
+    if($_POST['fileId'] != "null"){
         
         deleteAudioFile($fileId, $userId);
         

--- a/delete_user.php
+++ b/delete_user.php
@@ -1,5 +1,6 @@
 <?php
  require("mysql/mysqli_connect.php"); 
+ require("utilities/delete_files.php");
 
 //Delete records of a user from all tables in the database
 if($_POST['deleteSelectedUsers'] == 'true'){
@@ -21,6 +22,9 @@ if($_POST['deleteSelectedUsers'] == 'true'){
         
         $q = "SET foreign_key_checks = 1;";
         mysqli_query($dbcon, $q);
+
+        // all audio files that user uploaded will be deleted as well
+        deleteAllAudioFiles($userId);
     }
 }
 
@@ -44,6 +48,9 @@ else{
 
     $q = "SET foreign_key_checks = 1;";
     mysqli_query($dbcon, $q);
+
+    // all audio files that user uploaded will be deleted as well
+    deleteAllAudioFiles($userId);
 }
 
 

--- a/history_audio.php
+++ b/history_audio.php
@@ -158,7 +158,8 @@ $history = mysqli_query($dbcon, "SELECT * FROM text_translations t INNER JOIN au
 
 
       <input class = "removeBGM" type = "checkbox" name = "removeBGM">
-      <label for = "removeBGM">Remove BGM <br> <span style = "font-style: italic; color: red;">PS: Remove BGM before translating audio with music.</span></label>
+      <label for = "removeBGM">Remove BGM <br> <span style = "font-style: italic; color: red;">*Remove BGM before translating audio with music.</span></label>
+      <br><span style = "font-style: italic; color: red;">*Only a maximum of 60MB file is accepted.</span>
     </div>
  
 
@@ -209,8 +210,6 @@ $history = mysqli_query($dbcon, "SELECT * FROM text_translations t INNER JOIN au
                         <thead>
                             <tr>
                             <th>File Name</th>
-                            <th>File Type</th>
-                            <th>File Size</th>  
                             <th>Original Text</th>
                             <th>Source Language</th>
                             <th>Translated Text</th>

--- a/scripts/delete.js
+++ b/scripts/delete.js
@@ -231,9 +231,7 @@ function setNewRow(objData){
     //Sets new rows for audio to text history
     else{
         return "<tr id = " + objData['text_id'] + " class = '" + objData['user_id'] + " " + "a2t" + " " + objData['file_id']  + " paginate" + "'>" +
-        "<td class = " + objData['user_id'] + ">"  + objData['file_name'] + "</td>" + 
-        "<td class = " + objData['user_id'] + ">"  + objData['file_format'] + "</td>" +
-        "<td class = " + objData['user_id'] + ">"  + objData['file_size'] + "</td>" +
+        "<td class = '" + objData['user_id'] + " break-word'>"  + objData['file_name'] + "</td>" + 
         "<td class = '" + objData['user_id']+  " truncate-text'>" + objData['translate_from'] + "</td>" + 
         "<td class = " + objData['user_id'] + ">"  + objData['original_language'] + "</td>" + 
         "<td class = '" + objData['user_id'] +  " truncate-text'>" + objData['translate_to'] +  "</td>" +

--- a/scripts/translation_process.js
+++ b/scripts/translation_process.js
@@ -51,18 +51,18 @@ async function translationProcess(audio_info) {
         for (let i = 2; i <= 6; i++) {
             audio_info.set('step', i);
     
-            if (data.error != 0) { break; }                 // if there is an error, stop the loop
             if (i == 2 && removeBGM == 'off') { continue; } // skip step 2 if not remove BGM 
             
             displayLoadingMessage(i);
             
             data = await fetch('utilities/audio_translation.php', {
-                            method: "POST",
-                            body: audio_info,
-                        })
-                        .then(response => response.json())
-                        .catch(error => finishProcess(error));
-                        
+                method: "POST",
+                body: audio_info,
+            })
+            .then(response => response.json())
+            .catch(error => finishProcess(error));
+            
+            if (data.error != 0) { break; }                 // if there is an error, stop the loop
     
             // console.log(data);
         }

--- a/styles/style2.css
+++ b/styles/style2.css
@@ -1130,3 +1130,8 @@ select::after {
     width: auto;
 
 }
+
+.break-word {
+    word-break: break-word;
+    width: 13em;
+}

--- a/styles/style2.css
+++ b/styles/style2.css
@@ -594,7 +594,7 @@ body{
 .content main .bottom-data .orders{
     flex-grow: 1;
     flex-basis: 500px;
-    margin-bottom: 50px;
+    margin-bottom: 25px;
 }
 
 .content main .bottom-data .orders h2{
@@ -1165,5 +1165,5 @@ select::after {
 
 .dlpie-btn:hover{
     cursor: pointer;
-    background: rgb(96, 96, 230
+    background: rgb(96, 96, 230);
 }

--- a/utilities/Translator_Functions.php
+++ b/utilities/Translator_Functions.php
@@ -151,7 +151,7 @@ class Translator{
             while($row = mysqli_fetch_assoc($history)){
                 echo               
                 "<tr id = ". $row['text_id'] ." class = '". $row['user_id']. " " . "a2t". " " . $row['file_id'] .  " paginate" . "'>" .
-                "<td class = " .$row['user_id']. ">" .$row['file_name'] . "</td>" . 
+                "<td class = '" .$row['user_id']. " break-word'>" .$row['file_name'] . "</td>" . 
                 "<td class = '" .$row['user_id']. " truncate-text'>" .$row['translate_from'] . "</td>" . 
                 "<td class = " .$row['user_id']. ">" .$row['original_language'] . "</td>" . 
                 "<td class = '" .$row['user_id']. " truncate-text'>" .$row['translate_to'] . "</td>" .

--- a/utilities/Translator_Functions.php
+++ b/utilities/Translator_Functions.php
@@ -152,8 +152,6 @@ class Translator{
                 echo               
                 "<tr id = ". $row['text_id'] ." class = '". $row['user_id']. " " . "a2t". " " . $row['file_id'] .  " paginate" . "'>" .
                 "<td class = " .$row['user_id']. ">" .$row['file_name'] . "</td>" . 
-                "<td class = " .$row['user_id']. ">" .$row['file_format'] . "</td>" .
-                "<td class = " .$row['user_id']. ">" .$row['file_size'] . "</td>" .
                 "<td class = '" .$row['user_id']. " truncate-text'>" .$row['translate_from'] . "</td>" . 
                 "<td class = " .$row['user_id']. ">" .$row['original_language'] . "</td>" . 
                 "<td class = '" .$row['user_id']. " truncate-text'>" .$row['translate_to'] . "</td>" .

--- a/utilities/delete_files.php
+++ b/utilities/delete_files.php
@@ -1,0 +1,78 @@
+<?php 
+function removeFolder($path) {
+    // process of deleting the folder in audio files
+    if (is_dir($path)) {
+        $iterator = new DirectoryIterator($path);
+    
+        
+        // loop through each content inside the folder
+        foreach($iterator as $file) {
+            if ($file->isFile()) {
+                unlink($file->getRealPath()); // get the relative path and delete the file
+            } elseif (!$file->isDot() && $file->isDir()) {
+                rmdir($file->getRealPath()); // get the relative path and delete the folder
+            }
+        }
+        
+        // finally, delete the now-empty folder
+        rmdir($path);
+    }
+}
+
+function fetchAudioContent($fileid) {
+    global $dbcon;
+    $datequery = "SELECT file_name, DATE_FORMAT(upload_date, '%m%d%Y_%H%i%s') AS formatted_date 
+                        FROM audio_files WHERE file_id = '$fileid'";
+    $dateresult = mysqli_query($dbcon, $datequery);
+
+    $audiofile =  mysqli_fetch_assoc($dateresult);
+
+    // get the filename and extension
+    $filename = pathinfo($audiofile['file_name'], PATHINFO_FILENAME);
+    $extension = pathinfo($audiofile['file_name'], PATHINFO_EXTENSION);
+
+    // put filename, extension and date in array, these infos are needed to select
+    //  specific record from the database in order to delete a specific file
+    $info = array("filename" => $filename, 
+                "extension" => $extension,
+                "formatted_date" => $audiofile['formatted_date']);
+
+    return $info;
+}
+
+function deleteAudioFile($fileid, $userid) {
+    //get the audio file content from the database, to be used on locating the filename in audio_files folder
+    $audiofile = fetchAudioContent($fileid);
+
+    // remove the audio file uploaded by user
+    $filenameMask = "audio_files/" . $userid . "_" . $audiofile['filename'] . $audiofile['formatted_date'] . "." . $audiofile['extension']; 
+    if (file_exists($filenameMask)) 
+        unlink($filenameMask);
+    
+    // remove the folder created on specific file and all its contents
+    $folderMask = "audio_files/" . $userid . "_" . $audiofile['filename'] . $audiofile['formatted_date'];
+    removeFolder($folderMask);
+}
+
+function deleteAllAudioFiles($userid) {
+    // since we delete all, get all the files and folder that has the user_id in file
+    $mask = "audio_files/" . $userid . "_*";
+
+    // put all the folder/filenames that matches the $mask in an array
+    $items = glob($mask);
+
+    
+    foreach ($items as $file) {
+    
+        // check if it's an audio file or a folder, then delete them 
+        //  using their designated step
+        if (is_file($file)) {
+            unlink($file);
+        } elseif (is_dir($file)) {
+            removeFolder($file);
+        }
+    
+    }
+}
+
+?>


### PR DESCRIPTION
**### The update is about audio translation file deletion**
---
- added a functionality where in once user deletes a translation record, it would also delete the audio file saved in audio_files folder.
- added a delete_files.php in utilities that covers all functions required on deleting the files (includes fetching the needed information in audio_files table, removing the folder and its contents, deleting one file and deleting all files)

1.Once user delete a specific translation or selected a few translation records 
---
   After user clicks the 'yes' confirmation on deleting the translation, the program will get the needed information from the audio file before deleting it from the database and deleting the file itself. It needs the user_id, the filename, formatted upload date and its extension (.mp3, .wav, etc)

   Information gathered will be concatenated together to form the audio_file naming system and find it on the audio_files, then delete the file and its generated folder.

   If user selects many translation records, it would loop on each record until all records and audio files are deleted.

2.Once user deletes all the translation records
---
   The process of this deletion is we only get the user id, and find 'all' the audio files that has the record of the user's user_id in the filename since the filename consists of Userid_FilenameDate.Extension. All audio files

3.Once admin deletes a user
---
   this process is the same on number 2

###Further updates
---
- Removed File Type (because andon naman na sa filename eh)
- Removed File Size (I don't think user needs to know the size, but _if you have opinion, please let me know_)
- Added Disclaimer on file size must only be 60mb and below
- Added Word Break on filename in case user uploaded a too long filename without space breaks (ex. 385475710_6241822759256181_5558200081654469772_n.mp3)


uhh, i think that's all