### PR TITLE
fixed chinese language bug

### DIFF
--- a/index.php
+++ b/index.php
@@ -113,7 +113,7 @@ require ("utilities/recent_audio_translation.php");
                             <select name="src" id="sourceLanguage" class="form-control">
                                 <!--  Will display Languages supported by API and Whisper -->
                                 <option value="auto">Auto-Detect Language...</option>Auto-Detect
-                                <?php foreach ($whisper_langs as $lang => $code): ?>
+                                <?php foreach ($common_langs as $lang => $code): ?>
                                     <option name="language">
                                         <?= $lang ?>
                                     </option>
@@ -135,7 +135,7 @@ require ("utilities/recent_audio_translation.php");
                         <select name="target" id="targetLanguage" class="form-control">
                             <!-- Will display languages supported by API only-->
                             <option value="">Select One …</option>
-                            <?php foreach ($common_langs as $lang => $code): ?>
+                            <?php foreach ($deep_langs as $lang => $code): ?>
                                 <option name="language">
                                     <?= $lang ?>
                                 </option>

--- a/text-text.php
+++ b/text-text.php
@@ -67,7 +67,7 @@ require ("utilities/recent_text_translation.php");
                         <select name="src" id="sourceLanguage">
                             <option value="">Select One …</option>
                             <option name="language">auto</option>
-                            <?php foreach ($common_langs as $lang => $code): ?>
+                            <?php foreach ($deep_langs as $lang => $code): ?>
                                 <option name="language">
                                     <?= $lang ?>
                                 </option>
@@ -83,7 +83,7 @@ require ("utilities/recent_text_translation.php");
                     <select name="target" id="targetLanguage" class="form-control">
                         <!-- Will display languages supported by API only-->
                         <option value="">Select One …</option>
-                        <?php foreach ($common_langs as $lang => $code): ?>
+                        <?php foreach ($deep_langs as $lang => $code): ?>
                             <option name="language">
                                 <?= $lang ?>
                             </option>

--- a/utilities/audio_translation.php
+++ b/utilities/audio_translation.php
@@ -28,11 +28,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
         $pathsize = $_FILES['user_file']['size']; // file size
     }
 
-
-    //$userid = $_SESSION['user_id']; // to be used to add userid on new filename
-
-    //$model_size = $_POST['modelSize'];
-    $src_lang = ($_POST['src'] == 'auto') ? "auto" : $whisper_langs[$_POST["src"]] ?? '';  //($_POST['src'] == 'auto') ? "auto" : $common_langs[$_POST["src"]] ?? '';
+    $src_lang = ($_POST['src'] == 'auto') ? "auto" : $common_langs[$_POST["src"]] ?? '';  //($_POST['src'] == 'auto') ? "auto" : $common_langs[$_POST["src"]] ?? '';
     $trg_lang = $common_langs[$_POST["target"]] ?? '';
 
     // Checks whether checkbox is checked or not
@@ -40,7 +36,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 
 
     if ($_POST['step'] == 1) { #!!! error handling and insertion of audio file to database
-        ErrorHandling::checkLanguageChosen("audio", $whisper_langs, $common_langs);
+        ErrorHandling::checkLanguageChosen("audio", $deep_langs, $common_langs);
         if (!$is_recorded) {
             ErrorHandling::checkFileUpload($_FILES["user_file"]);
             ErrorHandling::validateFormat($path);
@@ -103,7 +99,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     if ($_POST['step'] == 5) {
         $trans_src = "";
         if ($_SESSION['a_info']['lang'] == 'zh') {
-            $trans_src = "zh-CN";
+            $trans_src = "chinese (simplified)";
         } else {
             $trans_src = $common_codes[$_SESSION['a_info']['lang']];
         }

--- a/utilities/common_languages.php
+++ b/utilities/common_languages.php
@@ -16,8 +16,8 @@ $deep_langs = Translator::getLangCodes();    // consists of supported languages 
 // changes the structure of the array.  {"name" => "code"}
 $whisper_langs = array_column($whisperlanguages, 'code', 'name');
 $common_langs = array_intersect($deep_langs, $whisper_langs);
-$common_langs['chinese (simplified)'] = "zh-CN";
-$common_langs['chinese (traditional)'] = "zh-TW";
+$common_langs['chinese'] = "zh";
+//$common_langs['chinese (traditional)'] = "zh-TW";
 $common_codes = array_flip($common_langs);
 
 ksort($common_langs);

--- a/utilities/error_handling.php
+++ b/utilities/error_handling.php
@@ -141,14 +141,14 @@ class ErrorHandling
 
 			// (3) Note: Source Language would be compared on common_languages of API and Whisper
 			if ($_POST['src'] != "auto") {
-				if (!array_key_exists($_POST['src'], $api_lang) || !array_key_exists($_POST['target'], $common_lang)) {
+				if (!array_key_exists($_POST['src'], $common_lang) || !array_key_exists($_POST['target'], $api_lang)) {
 					logs("error-at-6", $dbcon);
 
 					$exit = ['removeBGM' => 'error', 'error' => 6];
 					exit(json_encode($exit));
 				}
 			} else {
-				if (!array_key_exists($_POST['target'], $common_lang)) {
+				if (!array_key_exists($_POST['target'], $api_lang)) {
 					logs("error-at-6", $dbcon);
 
 					$exit = ['removeBGM' => 'error', 'error' => 6];


### PR DESCRIPTION
in error handling file
---
- changed the checking of array key exists,
- source must check the common langs
- target must check only the deep langs

in common languages.php
---
- removed traditional, added chinese with zh language code

in audio translation.php
---
- changed from whisper to deep langs in error check language chosen. We must not use whisper lang alone.
- changed zh-CN to chinese (simplified). Translator accepts full name of language

in text-text.php
---
- changed the common langs to deep_langs, since this is just translator. we do not need to combine whisper and deep_translator languages

in index.php
---
- changed languages
- source must get common_langs
- target must get deep_langs

# Further Comments:
- Further testing is RECOMMENDED especially foreign languages like Bengali, Filipino, Haitian Creole, etc.